### PR TITLE
Tag renderer

### DIFF
--- a/data.json
+++ b/data.json
@@ -35538,13 +35538,8 @@
               "children": [],
               "title": [
                 [
-                  "Link",
-                  {
-                    "url": ["Search", "Videos"],
-                    "label": [["Plain", ""]],
-                    "full_text": "[[Videos]]",
-                    "metadata": ""
-                  }
+                  "Tag",
+                  [["Plain", "Videos"]]
                 ]
               ],
               "body": [],

--- a/src/components/LSInline.js
+++ b/src/components/LSInline.js
@@ -2,6 +2,7 @@ import { getInlineContent, getInlineType, isInlineContainer } from '../utils'
 import LSBlockReference from './LSBlockReference'
 import LSInlines from './LSInlines'
 import LSLink from './LSLink'
+import LSTag from './LSTag'
 import LSSrc from './LSSrc'
 import LSTable from './LSTable'
 
@@ -31,6 +32,7 @@ function Emphasis({ c }) {
 const INLINE_RENDERERS = {
   Plain,
   Link: LSLink,
+  Tag: LSTag,
   Block_reference: LSBlockReference,
   Code,
   Src: LSSrc,

--- a/src/components/LSTag.js
+++ b/src/components/LSTag.js
@@ -1,0 +1,15 @@
+import { pageNames } from '../utils'
+import PageLink from './PageLink'
+
+export default function LSTag({ c }) {
+  const tag = c[0]
+  const tagType = tag[0]
+  if (tagType === 'Plain') {
+    const toPage = c[0][1]
+    if (pageNames.includes(toPage)) {
+      return <PageLink pageName={toPage} />
+    } else {
+      return toPage
+    }
+  }
+}


### PR DESCRIPTION
This fixes #5

I created an inline renderer component that renders items of Tag type as `PageLink` components.

I also adjusted the `data.json` file to include a tag, in order to demonstrate this working. This feels a little weird, so please let me know if there's a better way to show this.